### PR TITLE
Updated gulp tag from 4.0 to v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "beepbeep": "^1.2.0",
     "browser-sync": "^2.11.0",
     "colors": "^1.1.2",
-    "gulp": "git+https://github.com/gulpjs/gulp.git#4.0",
+    "gulp": "git+https://github.com/gulpjs/gulp.git#v4.0.0",
     "gulp-awspublish": "^3.0.1",
     "gulp-cli": "^1.1.0",
     "gulp-html-src": "^1.0.0",


### PR DESCRIPTION
Looks like at some point the gulp people changed their tag or branch for 4.0 so package.json needs to be updated to v4.0.0
