### PR TITLE
Conservatively collapse whitespace

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -129,6 +129,7 @@ function inliner(css) {
     .pipe($.replace, '<link rel="stylesheet" type="text/css" href="css/app.css">', '')
     .pipe($.htmlmin, {
       collapseWhitespace: true,
+      conservativeCollapse: true,
       minifyCSS: true
     });
 


### PR DESCRIPTION
See https://github.com/foundation/foundation-emails/issues/591

For this we have to upgrade html-minifier to the latest version or directly migrate to html-minifier-terser.