### PR TITLE
Added dynamic folder path for dist

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -18,7 +18,7 @@ const $ = plugins();
 // Look for the --production flag
 const PRODUCTION = !!(yargs.argv.production);
 const EMAIL = yargs.argv.to;
-
+const FOLDER_PATH = process.env.npm_config_path
 // Declar var so that both AWS and Litmus task can use it.
 var CONFIG;
 
@@ -45,7 +45,7 @@ gulp.task('zip',
 // Delete the "dist" folder
 // This happens every time a build starts
 function clean(done) {
-  rimraf('dist', done);
+  rimraf(FOLDER_PATH || 'dist', done);
 }
 
 // Compile layouts, pages, and partials into flat HTML files
@@ -59,7 +59,7 @@ function pages() {
       helpers: 'src/helpers'
     }))
     .pipe(inky())
-    .pipe(gulp.dest('dist'));
+    .pipe(gulp.dest(FOLDER_PATH || 'dist'));
 }
 
 // Reset Panini's cache of layouts and partials
@@ -77,30 +77,30 @@ function sass() {
     }).on('error', $.sass.logError))
     .pipe($.if(PRODUCTION, $.uncss(
       {
-        html: ['dist/**/*.html']
+        html: [`${FOLDER_PATH || 'dist'}/**/*.html`]
       })))
     .pipe($.if(!PRODUCTION, $.sourcemaps.write()))
-    .pipe(gulp.dest('dist/css'));
+    .pipe(gulp.dest(`${FOLDER_PATH || 'dist'}/css`));
 }
 
 // Copy and compress images
 function images() {
   return gulp.src(['src/assets/img/**/*', '!src/assets/img/archive/**/*'])
     .pipe($.imagemin())
-    .pipe(gulp.dest('./dist/assets/img'));
+    .pipe(gulp.dest(`${FOLDER_PATH || 'dist'}/assets/img`));
 }
 
 // Inline CSS and minify HTML
 function inline() {
-  return gulp.src('dist/**/*.html')
-    .pipe($.if(PRODUCTION, inliner('dist/css/app.css')))
-    .pipe(gulp.dest('dist'));
+  return gulp.src(`${FOLDER_PATH || 'dist'}/**/*.html`)
+    .pipe($.if(PRODUCTION, inliner(`${FOLDER_PATH || 'dist'}/css/app.css`)))
+    .pipe(gulp.dest(FOLDER_PATH || 'dist'));
 }
 
 // Start a server with LiveReload to preview the site in
 function server(done) {
   browser.init({
-    server: 'dist'
+    server: FOLDER_PATH || 'dist'
   });
   done();
 }
@@ -154,7 +154,7 @@ function aws() {
     'Cache-Control': 'max-age=315360000, no-transform, public'
   };
 
-  return gulp.src('./dist/assets/img/*')
+  return gulp.src(`${FOLDER_PATH || 'dist'}/assets/img/*`)
     // publisher will add Content-Length, Content-Type and headers specified above
     // If not specified it will set x-amz-acl to public-read by default
     .pipe(publisher.publish(headers))
@@ -170,10 +170,10 @@ function aws() {
 function litmus() {
   var awsURL = !!CONFIG && !!CONFIG.aws && !!CONFIG.aws.url ? CONFIG.aws.url : false;
 
-  return gulp.src('dist/**/*.html')
+  return gulp.src(`${FOLDER_PATH || 'dist'}/**/*.html`)
     .pipe($.if(!!awsURL, $.replace(/=('|")(\/?assets\/img)/g, "=$1"+ awsURL)))
     .pipe($.litmus(CONFIG.litmus))
-    .pipe(gulp.dest('dist'));
+    .pipe(gulp.dest(FOLDER_PATH || 'dist'));
 }
 
 // Send email to specified email for testing. If no AWS creds then do not replace img urls.
@@ -184,15 +184,15 @@ function mail() {
     CONFIG.mail.to = [EMAIL];
   }
 
-  return gulp.src('dist/**/*.html')
+  return gulp.src(`${FOLDER_PATH || 'dist'}/**/*.html`)
     .pipe($.if(!!awsURL, $.replace(/=('|")(\/?assets\/img)/g, "=$1"+ awsURL)))
     .pipe($.mail(CONFIG.mail))
-    .pipe(gulp.dest('dist'));
+    .pipe(gulp.dest(FOLDER_PATH || 'dist'));
 }
 
 // Copy and compress into Zip
 function zip() {
-  var dist = 'dist';
+  var dist = FOLDER_PATH || 'dist';
   var ext = '.html';
 
   function getHtmlFiles(dir) {
@@ -219,13 +219,13 @@ function zip() {
     var moveImages = gulp.src(sourcePath)
       .pipe($.htmlSrc({ selector: 'img'}))
       .pipe($.rename(function (currentpath) {
-        currentpath.dirname = path.join(fileName, currentpath.dirname.replace('dist', ''));
+        currentpath.dirname = path.join(fileName, currentpath.dirname.replace(FOLDER_PATH || 'dist', ''));
         return currentpath;
       }));
 
     return merge(moveHTML, moveImages)
       .pipe($.zip(fileName+ '.zip'))
-      .pipe(gulp.dest('dist'));
+      .pipe(gulp.dest(FOLDER_PATH || 'dist'));
   });
 
   return merge(moveTasks);


### PR DESCRIPTION
## What this feature does

Adding dynamic folder path in the command line scripts

## Description

To update the default path from the gulp serve concat the command with
`npm run <command-name> --path=/your-path`

The variable path can have relative as well as absolute path variables

## Example
- npm run zip --path=output
- npm run start --path=D:\Workspace\Projects\My Projects\Outsource\foundation-email